### PR TITLE
fix: Remove extra blank lines between todo items

### DIFF
--- a/pkg/too/output/templates/change_result.tmpl
+++ b/pkg/too/output/templates/change_result.tmpl
@@ -36,33 +36,25 @@
 {{- if eq $i 0 }}
 {{- if $isHighlighted }}
 {{$indent}}<highlighted-todo>{{$symbol}} {{$path}}. {{$line}}</highlighted-todo>
-
 {{- else if $hasHighlight }}
 {{$indent}}<muted>{{$symbol}} {{$path}}. {{$line}}</muted>
-
 {{- else }}
 {{- if $isDoneStatus }}
 {{$indent}}<completed-todo>{{$symbol}} {{$path}}. {{$line}}</completed-todo>
-
 {{- else }}
 {{$indent}}<active-todo>{{$symbol}} {{$path}}. {{$line}}</active-todo>
-
 {{- end }}
 {{- end }}
 {{- else }}
 {{- if $isHighlighted }}
 {{$indent}}<highlighted-todo>{{$lineIndent}}{{$line}}</highlighted-todo>
-
 {{- else if $hasHighlight }}
 {{$indent}}<muted>{{$lineIndent}}{{$line}}</muted>
-
 {{- else }}
 {{- if $isDoneStatus }}
 {{$indent}}<completed-todo>{{$lineIndent}}{{$line}}</completed-todo>
-
 {{- else }}
 {{$indent}}<active-todo>{{$lineIndent}}{{$line}}</active-todo>
-
 {{- end }}
 {{- end }}
 {{- end }}
@@ -70,6 +62,6 @@
 {{- if .Children }}
 {{- template "todoItem" dict "Todos" .Children "Level" (int (add $.Level 1)) "HighlightID" $.HighlightID }}
 {{- end }}
-{{ end }}
+{{- end }}
 {{- end }}
 


### PR DESCRIPTION
## Summary
- Fixed extra blank lines appearing between todo items in list output
- Removed unnecessary newlines in the change_result.tmpl template
- Template now properly controls whitespace using Go template syntax

## Test plan
- [x] Verified fix with live-tests/run live-tests/example.sh
- [x] All e2e tests pass without breaking test expectations
- [x] Output is now compact and readable without extra spacing

The issue was caused by extra newlines in the Go template that were adding blank lines between todo items, particularly noticeable with nested subtasks.

🤖 Generated with [Claude Code](https://claude.ai/code)