### PR TITLE
Fix environment isolation for live tests after .todos.json migration

### DIFF
--- a/live-tests/.wrapper
+++ b/live-tests/.wrapper
@@ -9,6 +9,11 @@ function export_history() {
     fi
 }
 
+# Create a wrapper function for too that always uses the correct data path
+function too() {
+    command too --data-path="${TODO_DB_PATH}" "$@"
+}
+
 # Set up color codes
 GRAY=$'\033[38;5;245m'
 NC=$'\033[0m'

--- a/live-tests/.zshrc
+++ b/live-tests/.zshrc
@@ -3,3 +3,8 @@ bindkey -v
 
 # Set custom prompt
 PS1="[too-test] $ "
+
+# Create a wrapper function for too that always uses the correct data path
+function too() {
+    command too --data-path="${TODO_DB_PATH}" "$@"
+}

--- a/live-tests/run
+++ b/live-tests/run
@@ -137,9 +137,12 @@ trap cleanup EXIT INT TERM
 # Change to temp directory
 cd "${TEMP_DIR}"
 
+# Set the environment variable to ensure todos are stored in the temp directory
+export TODO_DB_PATH="${TEMP_DIR}/.todos.json"
+
 # Always initialize a fresh .todos.json file
 echo -e "${GRAY}Initializing fresh .todos.json file${NC}"
-"${TOO_BIN}" init >/dev/null 2>&1
+"${TOO_BIN}" init --data-path="${TODO_DB_PATH}" >/dev/null 2>&1
 
 # Get version info
 VERSION_INFO=$("${TOO_BIN}" --version 2>&1 || echo "Version unknown")
@@ -164,6 +167,12 @@ export SAVEHIST=10000
 function export_history() {
     fc -ln 1 2>/dev/null || echo "# No history available"
 }
+
+# Create a wrapper function for too that always uses the correct data path
+function too() {
+    command too --data-path="${TODO_DB_PATH}" "$@"
+}
+export -f too
 
 # Function to launch interactive shell or execute script
 launch_shell() {


### PR DESCRIPTION
## Summary
- Fixed live tests that were broken after PR #173's migration from `.todos.db` to `.todos.json`
- Ensured proper environment isolation by using explicit `--data-path` flags
- All e2e tests now pass successfully (16/16 tests)

## Problem
After PR #173 changed the file extension from `.todos.db` to `.todos.json`, the live tests were failing because they were picking up the global `~/.todos.json` file instead of creating isolated test environments. The path resolution logic searches upward for existing files before checking environment variables, causing test pollution.

## Solution
1. Set `TODO_DB_PATH` environment variable in the test environment
2. Use `--data-path` flag explicitly with `too init` command
3. Create wrapper functions that ensure all `too` commands use `--data-path`

This prevents the path resolution logic from finding the global file and ensures tests run in truly isolated environments.

## Test Results
All e2e tests pass:
```
✓ create item at top level
✓ create two items at top level
✓ create children for each parent
✓ create grandchild for one of the children
✓ complete a child item
✓ completed items visible with --all but not without
✓ clean removes completed items
✓ complete parent preserves children status
✓ reopen completed items
✓ add todo with internal line breaks
✓ add multiple todos in single command
✓ add todo with very long text
✓ add nested todos using 'to' keyword
✓ edit todo text
✓ move todo to different parent
✓ reorder todos within same parent

16 tests, 0 failures in 22 seconds
```

🤖 Generated with [Claude Code](https://claude.ai/code)